### PR TITLE
Update nintendo.md

### DIFF
--- a/docs/megathread/nintendo.md
+++ b/docs/megathread/nintendo.md
@@ -42,6 +42,10 @@ DSiWare
 ## **Nintendo 3DS**<br/>
 3DS
 
+- |**Other: ALL**|**Links**|
+| ------ | ------ |
+| hShop 3DS Content in .cia Format and QR Codes | [Link](https://hshop.erista.me) |
+
 - |**Google Drive: ALL**|**Links**|
 | ------ | ------ |
 | No-Intro Nintendo (NEW)3DS 2017/2018 | [Link](https://drive.google.com/drive/folders/1R5c6-nY5mMns8G1u2tcbYumfTCGXDQ5w) |


### PR DESCRIPTION
Added an entry in the Nintendo section for hShop. hShop is an ad-free website with direct download links and QR codes to download 3DS games, updates, DLC, Virtual Console titles, DSiWare, and themes in .cia format.