### PR TITLE
Add archive.org items to others tab

### DIFF
--- a/docs/megathread/other.md
+++ b/docs/megathread/other.md
@@ -33,7 +33,7 @@ FinalBurn Neo
 | TOSEC 2018-12-27 | [Link](https://archive.org/download/TOSEC_Main_Branch_Release_2018-12-27) |
 | EverDrive 2018 Torrent | [Link](https://pastebin.com/raw/ywTQeDmS) |
 
-mobasuitecom No-Intro
+mobasuite.com No-Intro
 
 - |**System**|**Links**|
 | ------ | ------ |

--- a/docs/megathread/other.md
+++ b/docs/megathread/other.md
@@ -61,6 +61,31 @@ mobasuite.com No-Intro
 | Sega - Mega Drive - Genesis | [Link](http://90.230.15.92/Sega%20-%20Mega%20Drive%20-%20Genesis/) |
 | Sega - SG-1000 | [Link](http://90.230.15.92/Sega%20-%20SG-1000/) |
 
+archive.org No-Intro
+
+- |**System**|**Links**|
+| ------ | ------ |
+| Atari - 2600 | [Link](https://archive.org/download/nointro.atari-2600) |
+| Atari - 5200 | [Link](https://archive.org/download/nointro.atari-5200) |
+| Atari - 7800 | [Link](https://archive.org/download/nointro.atari-7800) |
+| NEC - PC Engine - TurboGrafx 16 | [Link](https://archive.org/download/nointro.tg-16) |
+| Nintendo - Family Computer Disk System | [Link](http://archive.org/download/nointro.fds) |
+| Nintendo - Game Boy Advance (Multiboot) | [Link](https://archive.org/download/nointro.gba-multiboot) |
+| Nintendo - Game Boy Advance | [Link](https://archive.org/download/nointro.gba) |
+| Nintendo - Game Boy Color | [Link](https://archive.org/download/nointro.gbc) |
+| Nintendo - Game Boy | [Link](https://archive.org/download/nointro.gb) |
+| Nintendo - Nintendo 64 | [Link](https://archive.org/download/nointro.n64) |
+| Nintendo - Nintendo 64DD | [Link](https://archive.org/download/nointro.n64dd) |
+| Nintendo - Nintendo Entertainment System | [Link](https://archive.org/download/nointro.nes) |
+| Nintendo - Pokémon Mini | [Link](http://archive.org/download/nointro.poke-mini) |
+| Nintendo - Super Nintendo Entertainment System | [Link](https://archive.org/download/nointro.snes) |
+| Nintendo - Virtual Boy | [Link](https://archive.org/download/nointro.vb) |
+| Nintendo - e-Reader | [Link](http://archive.org/download/nointro.e-reader) |
+| Sega - 32X | [Link](https://archive.org/download/nointro.32x) |
+| Sega - Game Gear | [Link](https://archive.org/download/nointro.gg) |
+| Sega - Master System - Mark III | [Link](https://archive.org/download/nointro.ms-mkiii) |
+| Sega - Mega Drive - Genesis | [Link](https://archive.org/download/nointro.md) |
+
 ## **Miscellaneous**
 
 - |**Miscellaneous**|**Links**|


### PR DESCRIPTION
Adds an additional section to the others tab for archive.org items.

Should others want to add additional mirrors eventually I figure multiple links can be added per system line in the following way with a '/' followed by additional link(s):
(Note that currently there is only one link per system listed in this section in the actual commit)
![Untitled](https://user-images.githubusercontent.com/25729145/111857211-55f71f80-8906-11eb-9637-a3d969feaf49.png)