### PR TITLE
Begin archive.org Redump section in others tab

### DIFF
--- a/docs/megathread/other.md
+++ b/docs/megathread/other.md
@@ -59,6 +59,12 @@ archive.org No-Intro
 | Sega - Master System - Mark III | [Link](https://archive.org/download/nointro.ms-mkiii) |
 | Sega - Mega Drive - Genesis | [Link](https://archive.org/download/nointro.md) |
 
+archive.org Redump
+
+- |**System**|**Links**|
+| ------ | ------ |
+| NEC - PC Engine CD & TurboGrafx CD | [Link](https://archive.org/details/redump.pce.revival) |
+
 ## **Miscellaneous**
 
 - |**Miscellaneous**|**Links**|


### PR DESCRIPTION
Begins an additional section in the others tab for Redump, figured to add this system since someone was looking for it and couldn't find it in any other tabs.