### PR TITLE
remove all dead google drive links

### DIFF
--- a/docs/megathread/microsoft.md
+++ b/docs/megathread/microsoft.md
@@ -6,45 +6,9 @@ Older systems can be found in the [Others Tab](/megathread/other)<br/>
 ## **Microsoft Xbox**<br/> 
 Xbox
 
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| Xbox | [Link](https://drive.google.com/drive/folders/1m7Zf72XX4M2nQjI4zGRw8aZPtQqm79YP) |
-
 - |**Internet Archive: Multiple**|**Links**|
 | ------ | ------ |
 | Xbox HDD Ready Part 1 | [Link](https://archive.org/details/XBOX_HDD_READY) |
 | Xbox HDD Ready Part 2 | [Link](https://archive.org/details/XBOX_HDD_READY_2) |
 | Xbox HDD Ready Part 3 | [Link](https://archive.org/details/XBOX_HDD_READY_2_201710) |
 | Xbox HDD Ready Part 4 | [Link](https://archive.org/details/XBOX_HDD_READY_3) |
-
-## **Microsoft Xbox 360**<br/> 
-Xbox 360
-
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| ISO | [Link](https://drive.google.com/drive/folders/1vTk6alNUwMCo5RarcOiyHvPFjdTlTfwu) |
-| DLC | [Link](https://drive.google.com/drive/folders/1YpVTuyNb3xoFz4q7JGsWzXm1fGcFCzGD) |
-
-## **Other**<br/>
-Xbox Live Arcade
-
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-|XBLA| [Link](https://drive.google.com/drive/folders/1YOuaQHFW_Ic_sQg1--FvyBbmqxLXrJRj) |
-| XBLA DLC| [Link](https://drive.google.com/drive/folders/1IkhUA6YGZeL1uZjCdeG5JVmRXP684VKe) |
-
-Xbox Live Indie Games
-
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| XBLIG | [Link](https://drive.google.com/drive/folders/1eJz3kYUSSkvjUBs88LZZxT4bm-E_8w3L) |
-| XNA Title Update.rar| [Link](https://drive.google.com/drive/folders/1jAPoCui1f4hysh85nB6OAwkN9IH-z0ed) |
-
-Xbox Classic JTAG
-
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| XBOX CLASSIC ISO | [Link](https://drive.google.com/drive/folders/1utNRA6jbt19UCMGLYHo7qg6d6jJuoVhJ) |
-| XDVD MULLETER + DMI + PFI + SS | [Link](https://drive.google.com/drive/folders/1VFpqp_rC5SivnjNc0EhOLxXAuYIK8oO2) |
-| Xbox CLASSIC JTAG | [Link](https://drive.google.com/drive/folders/1qWdADm1eYd7ADjvON0N9MkzPYn8WfmFL) |
-| Xbox 360 Backwards Compatibility | [Link](https://drive.google.com/drive/folders/1raK5FRJsWSWR5YfueV_aed33J97K3SDU) |

--- a/docs/megathread/nintendo.md
+++ b/docs/megathread/nintendo.md
@@ -11,10 +11,6 @@ DS
 | ------ | ------ |
 | No-Intro - Nintendo DS (Decrypted) (2020-01-20) | [Link](https://archive.org/details/noIntroNintendoDsDecrypted2020Jan20) |
 
-- |**Google Drive: All**|**Links**| 
-| ------ | ------ |
-| AlvRo Rebranded Mirror, NDS Numbered ROMs | [Link](https://drive.google.com/drive/folders/1s3zKz90Nb-5L3LemxaCTcc5V9fZ4z00o) |
-
 - |**Other: All**|**Links**| 
 | ------ | ------ |
 | Squid-Proxy No-Intro | [Link](https://www.squid-proxy.xyz/Games/Nintendo%20DS/) |
@@ -62,26 +58,6 @@ DSiWare
 - |**Mega: ALL**|**Links**|
 | ------ | ------ |
 | 3DS ROMs| [Link](https://drive.google.com/file/d/1r1CS6UVPLafPbCFM7sjF1baupsEr5APH/view) (This contains megalinks, read the top of the document for instructions) |
-
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| 3DS ROMs Scene No RAR | [Link](https://drive.google.com/drive/folders/1Gd5cJUstN6gwZI9lKzHcDWJ-kh0ktexL) |
-| 3DS eShop Scene No RAR | [Link](https://drive.google.com/drive/folders/1MDy65pGaoIOmoIg__fey3b_CjKNm3Ujc) |
-| 3DS x-files | [Link](https://drive.google.com/drive/folders/1BLaIl4v3cgmdpoXx8bB7q33Vvh_mt32n) |
-| 3DS CIA Scene No RAR| [Link](https://drive.google.com/drive/folders/1FWWm3qNg_HHANTmEeY_SxRRabUm_3wgC) |
-| 3DS CIA eShop Scene No RAR | [Link](https://drive.google.com/drive/folders/1Y8yGQ9-tTWdleCbTMiEI4-XiFOYLpcNs) |
-| 3DS CIA DLC | [Link](https://drive.google.com/drive/folders/1ARm3uFESLi9r1pbym_XR5lNbDb8_BUDS) |
-| 3DS CIA Updates | [Link](https://drive.google.com/drive/folders/17ltCPytHV4qSftGPvFwxGBfmfiwJfjjU) |
-| 3DS Legit CIA All | [Link](https://drive.google.com/drive/folders/1G7o0kFXpT4Qzwehe_rrs_zWqn45nCkYV) |
-| 3DS Decrypted Citra | [Link](https://drive.google.com/drive/folders/1JPW_yrSrqF_hnXtlpR-6-qXUitEAeQXz) |
-| 3DS Decrypted Citra eShop | [Link](https://drive.google.com/drive/folders/1BHCXsJYQvqsalW5IaU4N9bkCdhU1fILB)|
-| 3DS No-Intro | [Link](https://drive.google.com/drive/folders/1oImDLb5j8FtXnrQy9VVSRVOYVutJVbI4) |
-| 3DS No-Intro eShop | [Link](https://drive.google.com/drive/folders/1u8Ro8KtCPPAy6eOIZ7KlFF8u-LJEj7l0) |
-| N3DS No-Intro | [Link](https://drive.google.com/drive/folders/1hRsLubAne0hFHxJ9K7eJORc4n0pCCDFG) |
-| N3DS No-Intro eShop | [Link](https://drive.google.com/drive/folders/1siyQFUEqqtc9z-SBtqAjvxjfi2zmx0sy) |
-| 3DS .cia No-Intro | [Link](https://drive.google.com/drive/folders/1igGdcIznoZiloF8RK0Jwbn2YZI5nztyo) |
-| 3DS .cia No-Intro eShop | [Link](https://drive.google.com/drive/folders/1hWKO_6v7ud_WXB9RxDB2MuwLqvuPmFhc) |
-| N3DS .cia No-Intro | [Link](https://drive.google.com/drive/folders/1GW2MQxIol-HlOn4eN4NZZTXttnsi54pQ) |
 
 - **.3ds/.cia Decryption Instructions:**
 
@@ -170,21 +146,3 @@ Wii U
 - |**Tools**|**Links**|
 | ------ | ------ |
 | Wii U USB Helper | [Link](https://www.reddit.com/r/CemuPiracy/comments/bszm0p/how_to_set_up_wii_u_usb_helper_after_its/) (Note: to use files with cemu emulator, check the checkbox that says `Unpack`)
-
-- |**Scene Games**|**Links**|
-| ------ | ------ |
-| Alvro Rebranded Mirror, Wii U Scene Games | [Link](https://drive.google.com/drive/folders/1k6bhO9VhZWdq7Lz6fY6RxOrs9D8lm2ks) |
-
-- |**NUS Format**|**Links**|
-| ------ | ------ |
-| Wii U NUS Disc | [Link](https://drive.google.com/drive/folders/1l5yBGCynkNLeC0CbSZKoSiFmwd7_mTVt) |
-| Wii U NUS Download All Regions | [Link](https://drive.google.com/drive/folders/1NCiboZf3uTD3sVPkTN288s-mpbRkgYwX) |
-| Wii U NUS Retail All Regions | [Link](https://drive.google.com/drive/folders/1gG4_3uQAQaWJrg9LC4KjcYFsfxI4xb17) |
-| Wii U NUS Virtual Console | [Link](https://drive.google.com/drive/folders/14WAI96ztCoJtm-XsAsN6S0qL5XdDHDwV) |
-
-- |**RAW Format**|**Links**|
-| ------ | ------ |
-| Wii U RAW Disc | [Link](https://drive.google.com/drive/folders/1B9h4tg0GTP1MoWdhCq2jhTsU7UsTOkA5) |
-| Wii U RAW Download All Regions | [Link](https://drive.google.com/drive/folders/1Zo8xAsmHJehtMJ8dK3AFIP8lA1nHcVLT) |
-| Wii U RAW Retail All Regions | [Link](https://drive.google.com/drive/folders/1uvkvNEbSzOb6xQhxIUjpm0d7M-ewLCv4) |
-| Wii U RAW Virtual Console | [Link](https://drive.google.com/drive/folders/1mjHeJV_eW3lqIEWW7-2KLy7iU8AJH3uE) |

--- a/docs/megathread/other.md
+++ b/docs/megathread/other.md
@@ -95,6 +95,4 @@ edge|emulation - [Link](https://edgeemu.net/)
 
 Vimm's Lair - [Link](https://vimm.net/?p=vault)
 
-Alvro Rebranded Mirror Google Drive - [Link](https://drive.google.com/drive/folders/1rEtYPc8XTTrfye-dNXuhwBqnny33ZLeB)
-
 mobasuite.com's ROM server - [Link](http://90.230.15.92/)

--- a/docs/megathread/popular.md
+++ b/docs/megathread/popular.md
@@ -103,7 +103,6 @@ Zelda Games
 
 - |**Legend of Zelda**|**Links**|
 | ------ | ------ |
-| Legend of Zelda Breath of the Wild (Wii U) (USA) | [Game](https://drive.google.com/file/d/1CckvkzzQ8onTOcceKX_HIC9reu9RYw5I/view?usp=sharing) / [DLC](https://drive.google.com/file/d/1vtE7EMMRw3WggWb2YmcC0kdYbNEbjjmL/view?usp=sharing) / [Update](https://drive.google.com/file/d/1_a8omXQOJ2s1M8Ae2YPWKBIA5aF8CzgK/view?usp=sharing)  (for use with Cemu, use [CDecrypt](https://wiki.agilly1989.xyz/books/wiiu/page/cdecrypt) to unpack the files) |
 | Legend of Zelda Twilight Princess (Wii) (USA) | [Link](https://archive.org/download/WiiRedumpNKitPart4/Legend%20of%20Zelda%2C%20The%20-%20Twilight%20Princess%20%28USA%29/Legend%20of%20Zelda%2C%20The%20-%20Twilight%20Princess%20%28USA%29.nkit.gcz) |
 | Legend of Zelda Twilight Princess (GC) (USA) | [Link](https://archive.org/download/GCRedumpNKitPart1/Legend%20of%20Zelda%2C%20The%20-%20Twilight%20Princess%20%28USA%29.nkit.gcz) |
 | Legend of Zelda Skyward Sword (Wii) (USA)| [Link](https://archive.org/download/WiiRedumpNKitPart4/Legend%20of%20Zelda%2C%20The%20-%20Skyward%20Sword%20%28USA%29%20%28En%2CFr%2CEs%29/Legend%20of%20Zelda%2C%20The%20-%20Skyward%20Sword%20%28USA%29%20%28En%2CFr%2CEs%29.nkit.gcz) |
@@ -117,15 +116,5 @@ Super Smash Bros Games
 
 - |**Super Smash Bros**|**Links**| 
 | ------ | ------ |
-| Super Smash Bros Wii U | [Game](https://drive.google.com/file/d/1lbLLPYJQM3Y5oRoB74XLsFOVLbXFFgs-/view?usp=sharing) / [DLC](https://drive.google.com/file/d/1Jh6CNafyvrTFkS-36UVCEMDn0xKn4_SX/view?usp=sharing) / [Update](https://drive.google.com/file/d/1mXwmcZf6Z-tRm8Dmkb7tjbz_qZFx5YHf/view?usp=sharing)  (for use with Cemu, use [CDecrypt](https://wiki.agilly1989.xyz/books/wiiu/page/cdecrypt) to unpack the files) |
 | Super Smash Bros Brawl ISO (Wii)| [Link](https://archive.org/download/WiiRedumpNKitPart7/Super%20Smash%20Bros.%20Brawl%20%28USA%29%20%28Rev%201%29/Super%20Smash%20Bros.%20Brawl%20%28USA%29%20%28Rev%201%29.nkit.gcz) |
 | Super Smash Bros Melee v1.02 ISO (GC)| [Link](https://archive.org/download/GCRedumpNKitPart2/Super%20Smash%20Bros.%20Melee%20%28USA%29%20%28En%2CJa%29.nkit.gcz) | 
-
-## Xenoblade<br/>
-
-Xenoblade Games
-
-- |**Xenoblade**| **Links** |
-| ------ | ------ |
-| Xenoblade Chronicles (Wii) (USA)| [Link](https://archive.org/download/WiiRedumpNKitPart8/Xenoblade%20Chronicles%20%28USA%29%20%28En%2CFr%2CEs%29/Xenoblade%20Chronicles%20%28USA%29%20%28En%2CFr%2CEs%29.nkit.gcz) |
-| Xenoblade Chronicles X (Wii U) (USA) | [Game](https://drive.google.com/file/d/1_GYMvb3y54sYIHJhUyGNt9S8zIiFB2kc/view?usp=sharing) / [DLC](https://drive.google.com/file/d/1eXrKAlaQZMghVAv_Q6zj-akvFqS9OT8x/view?usp=sharing) / [Update](https://drive.google.com/file/d/1i-9Lzbq5vakIlvt6oGWquewGFWa9hke6/view?usp=sharing) (for use with Cemu, use [CDecrypt](https://wiki.agilly1989.xyz/books/wiiu/page/cdecrypt) to unpack the files) |

--- a/docs/megathread/popular.md
+++ b/docs/megathread/popular.md
@@ -118,3 +118,11 @@ Super Smash Bros Games
 | ------ | ------ |
 | Super Smash Bros Brawl ISO (Wii)| [Link](https://archive.org/download/WiiRedumpNKitPart7/Super%20Smash%20Bros.%20Brawl%20%28USA%29%20%28Rev%201%29/Super%20Smash%20Bros.%20Brawl%20%28USA%29%20%28Rev%201%29.nkit.gcz) |
 | Super Smash Bros Melee v1.02 ISO (GC)| [Link](https://archive.org/download/GCRedumpNKitPart2/Super%20Smash%20Bros.%20Melee%20%28USA%29%20%28En%2CJa%29.nkit.gcz) | 
+
+## Xenoblade<br/>
+
+Xenoblade Games
+
+- |**Xenoblade**| **Links** |
+| ------ | ------ |
+| Xenoblade Chronicles (Wii) (USA)| [Link](https://archive.org/download/WiiRedumpNKitPart8/Xenoblade%20Chronicles%20%28USA%29%20%28En%2CFr%2CEs%29/Xenoblade%20Chronicles%20%28USA%29%20%28En%2CFr%2CEs%29.nkit.gcz) |

--- a/docs/megathread/sega.md
+++ b/docs/megathread/sega.md
@@ -18,9 +18,7 @@ Older systems can be found in the [Others Tab](/megathread/other)<br/>
 
 - |**Google Drive: ALL**|**Links**|
 | ------ | ------ |
-| Alvro Rebranded Mirror | [Link](https://drive.google.com/drive/folders/1gJvfa6RbFTgRJeMxhDVqRkSa86Pzm_OP) |
 | CDI Collection | [Link](https://docs.google.com/spreadsheets/d/14fCQ3NXIlW1ZC_gjIejpQVPG34fLWmSoXYgSTyxdRWM/edit#gid=0) |
-| TiZ Homebrew Games | [Link](https://drive.google.com/drive/folders/1qIlLS51uBLEmsguvxNTWj8Qg2BAyF1dE) |
 | TiZ Homebrew Apps | [Link](https://mega.nz/#F!q7oxzDga!JfJulP8EX1-poB0nkgy2ZA) |
 
 Note: Not all Dreamcast emulators support CUE/BIN, GDI is recommended to ensure that the game can run.
@@ -36,12 +34,6 @@ Note: Not all Dreamcast emulators support CUE/BIN, GDI is recommended to ensure 
 | Redump Sega Saturn .CHD JPN | [Link](https://archive.org/download/chd_saturn/CHD-Saturn/Japan/) | 
 | Redump Sega Saturn .CHD Other | [Link](https://archive.org/download/chd_saturn/CHD-Saturn/Other-Regions/) | 
 
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| Sega Saturn ISO Europe | [Link](https://drive.google.com/drive/folders/11FRcw9NoM6X3mM4qm2sqvVEw-N763oGH) |
-| Sega Saturn ISO Japan | [Link](https://drive.google.com/drive/folders/1R61XOnfZg3rzXvKwtGn7ngfo_Hqn3p7s) |
-| Sega Saturn ISO USA | [Link](https://drive.google.com/drive/folders/11e69IUrrKJ_wTGSdGUuDXB4LLuG2JYHv) |
-
 ## **Sega CD**<br/>
 <br/>CD & Mega CD
 
@@ -51,8 +43,3 @@ Note: Not all Dreamcast emulators support CUE/BIN, GDI is recommended to ensure 
 | Redump Sega CD & Mega CD .CHD USA | [Link](https://archive.org/download/chd_segacd/CHD-SegaCD-NTSC/) |
 | Redump Sega CD & Mega CD .CHD EUR | [Link](https://archive.org/download/chd_segacd/CHD-MegaCD-PAL/) |
 | Redump Sega CD & Mega CD .CHD JPN | [Link](https://archive.org/download/chd_segacd/CHD-MegaCD-NTSCJ/) |
-
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| Sega Mega CD | [Link](https://drive.google.com/drive/folders/1oGayIffep4QioAjV2hTyBaEpa_VqUfU4) |
-| Sega Mega CD Redump | [Link](https://drive.google.com/drive/folders/1RuHTIyg6V4f2V-X5rYLsWRXOj-Nla6y-) |

--- a/docs/megathread/sony.md
+++ b/docs/megathread/sony.md
@@ -24,12 +24,6 @@ PS1
 ## **Sony Playstation 2**<br/>
 PS2
 
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| Europe | [Link](https://drive.google.com/drive/folders/19lQ2WXShHBWNnuL34EPgugNTGVIW9OPt) |
-| USA | [Link](https://drive.google.com/drive/folders/1tE8uKfEVA3t4Ic7a2cfC28COtRQlo7X8) |
-| Japanese | [Link](https://drive.google.com/drive/folders/1HdKHkKKXd494fuXsFKACs_VENI1JG7DN) |
-
 - |**Internet Archive: USA**|**Links**|
 | ------ | ------ |
 | PS2 Redump USA Part 1 2018-08-01 | [Link](https://archive.org/download/redumpSonyPlaystation2UsaGames2018Aug01) |
@@ -38,15 +32,6 @@ PS2
 | PS2 Redump USA Part 4 2018-08-01 | [Link](https://archive.org/download/redumpSonyPlaystation2UsaGames2018Aug01Part4) |
 | PS2 Redump USA Part 5 2018-08-01 | [Link](https://archive.org/download/redumpSonyPlaystation2UsaOther2018Aug01) |
 
-## **Sony Playstation 3**<br/>
-PS3
-
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| PS3 ISO | [Link](https://drive.google.com/drive/folders/1DlsZIGn-EtRzgoPPNVMTFsXH-ykXJOcx) |
-| PSN | [Link](https://drive.google.com/drive/folders/1ako0uO8UCyFPOf25jFFTXWJw4_1Yq49c) |
-| PSN No-Intro All Regions | [Link](https://drive.google.com/drive/folders/1Rmp7wIZ-MrBgPxAu48t07_3z7ICzDhht) |
-
 ## **Sony Playstation Portable**<br/>
 PSP
 
@@ -54,26 +39,6 @@ PSP
 | ------ | ------ |
 | Redump PSP ISO Part 1 | [Link](https://archive.org/download/redump.psp) |
 | Redump PSP ISO Part 2 | [Link](https://archive.org/download/redump.psp.p2) |
-
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| Games by number | [Link](https://drive.google.com/drive/folders/1bnwkRPz0Kbdj-tEsBXsoeNc6ZjF1GwU2) |
-| Games by letter | [Link](https://drive.google.com/drive/folders/15feAVYtmtF4A9qEylsD0536ReX7PQYGl) |
-| UMD Music | [Link](https://drive.google.com/drive/folders/1GtTHVUeeB0xQNkcq3V30vNFby24YpHfe) |
-| PSX2PSP | [Link](https://drive.google.com/drive/folders/1ExPkcPbIC9bMZAcya5c72vn_flk6OBU6) |
-| PSN | [Link](https://drive.google.com/drive/folders/1NtVUC0L7CvbNZP2s5yutuye9LstKf6mS) |
-| PSN DLC | [Link](https://drive.google.com/drive/folders/1xKmpV5dglj0W8cLH4GHXeE5BhLLv_DtT) |
-
-## **Sony Playstation Vita**<br/>
-PS Vita
-
-- |**Google Drive: ALL**|**Links**|
-| ------ | ------ |
-| VPK | [Link](https://drive.google.com/drive/folders/1Ju3RuYDUqV54UcvyMRuoiGUH-dkfj_9j) |
-| Patched | [Link](https://drive.google.com/drive/folders/1SMtzuE0EaRqjuunVIoUGQnkhYS4BoRmO) |
-| VPK No-Intro | [Link](https://drive.google.com/drive/folders/175-iMS6cwcLNd7l1JF1O_B8ikBKmAqZ0) |
-| PSN | [Link](https://drive.google.com/drive/folders/1S96pjVr-KLsmlb6m7bcHcgl4glp90aSz) |
-| MaiDump | [Link](https://drive.google.com/drive/folders/15xhmueFKMyQ6Oi8FnT2eDe87C5Ksgvyh) |
 
 ## **For More Games/Updates/DLCs**<br/>
 If you still cannot find what you are looking for, check [NoPayStation](https://nopaystation.com/)


### PR DESCRIPTION
The owner's google account was disabled, causing all of the files linked to that account to be deleted.