### PR TITLE
Add PS1 .CHD USA link back

### DIFF
--- a/docs/megathread/sony.md
+++ b/docs/megathread/sony.md
@@ -17,14 +17,12 @@ PS1
 | PS1 Redump .CUE/.BIN Part 1 | [Link](https://archive.org/download/redump.psx) |
 | PS1 Redump .CUE/.BIN Part 2 | [Link](https://archive.org/download/redump.psx.p2) |
 | PS1 Redump .CUE/.BIN Part 3 | [Link](https://archive.org/download/redump.psx.p3) |
-| PS1 Redump .CUE/.BIN Part 4 | [Link](https://archive.org/download/redump.psx.p4) | 
+| PS1 Redump .CUE/.BIN Part 4 | [Link](https://archive.org/download/redump.psx.p4) |
+| PS1 Redump .CHD USA | [Link](https://archive.org/download/chd_psx/CHD-PSX-USA/)
 | PS1 Redump .CHD EUR | [Link](https://archive.org/download/chd_psx_eur/CHD-PSX-EUR/) |
 | PS1 Redump .CHD JPN Part 1 | [Link](https://archive.org/download/chd_psx_jap/CHD-PSX-JAP/) |
 | PS1 Redump .CHD JPN Part 2 | [Link](https://archive.org/download/chd_psx_jap_p2/CHD-PSX-JAP/) |
 | PS1 Redump .CHD Misc | [Link](https://archive.org/download/chd_psx_misc/CHD-PSX-Misc/) |
-<!--- 
-| PS1 Redump .CHD USA | [Link](https://archive.org/download/chd_psx/CHD-PSX-USA/) | 
---->
 
 ## **Sony Playstation 2**<br/>
 PS2


### PR DESCRIPTION
I found this post on reddit, showing that the USA .chd collection is back up. It's by the same uploader as the other .chd collections, so I assume it's safe. https://www.reddit.com/r/Roms/comments/qrkg29/chd_psx_set_its_back/