### PR TITLE
Unify notes + little explanation in commit comment

### DIFF
--- a/docs/megathread/sony.md
+++ b/docs/megathread/sony.md
@@ -182,6 +182,8 @@ PS3
 ## **Sony Playstation Vita**<br/>
 PS Vita
 
+#### Note: [NoPayStation](https://nopaystation.com/) is highly recommended for PS Vita games. Please only check the links below if you are looking for content NoPayStation does not have.
+
 - |**Internet Archive: All**|**Links**|
 | ------ | ------ |
 | PSVITA VPK | [Link](https://archive.org/download/PSVITA_VPK) |


### PR DESCRIPTION
If you are adding notes be consistent about it for all major platforms it supports. 

Reason why Vita's note is more important than ps3's is that NPS started as Vita centered service, especially since Mai/VPK are considered nuked by scene, as their modules & executables are highly modified by software that dumped them from RAM memory (which introduced A LOT of glitches and bugs), while PKG+Zrif combo gives you usable unmodified encrypted files. Vita3K emulator supports NPS downloaded games so there is no excuse to seek VPK/Mai dumps.   
Almost all vita titles had digital releases (98,74% coverage in US region), while PS3 disk dumps can still fill the gaps for ps3 titles that were never released as digital.   
This being said, I'm not removing VPK/Mai links in this commit in case someone finds niche usage for them.

Can add brief appropriate explanation to the sony page if requested, but what I wrote here should be enough for maintainers to write note of their own.