### PR TITLE
Point to Wayback Machine for AES Keys

### DIFF
--- a/docs/megathread/nintendo.md
+++ b/docs/megathread/nintendo.md
@@ -56,7 +56,7 @@ If Citra says the ROM is encrypted, use [Batch CIA-3DS Decryptor](https://gbatem
 
 If you would like to get a proper No-Intro hash from the converted file, use [this script](https://archive.org/download/pkmn_collection/3DS%20%2B%20CIA%20Rom%20Script.rar).
 
-Or, add the following AES keys to Citra from [here](https://pastebin.com/tBY6RHh4). 
+Or, add the following AES keys to Citra from [here](https://web.archive.org/https://pastebin.com/tBY6RHh4). 
 Click download on Pastebin to download the text in the file as a TXT. Then, follow the installation instructions below for your OS.
 
 **Windows Installation Instructions**

--- a/docs/megathread/nintendo.md
+++ b/docs/megathread/nintendo.md
@@ -56,7 +56,7 @@ If Citra says the ROM is encrypted, use [Batch CIA-3DS Decryptor](https://gbatem
 
 If you would like to get a proper No-Intro hash from the converted file, use [this script](https://archive.org/download/pkmn_collection/3DS%20%2B%20CIA%20Rom%20Script.rar).
 
-Or, add the following AES keys to Citra from [here](https://web.archive.org/https://pastebin.com/tBY6RHh4). 
+Or, add the following AES keys to Citra from [here](https://pastebin.com/vRy8c6JP). ([backup link](https://web.archive.org/https://pastebin.com/tBY6RHh4))
 Click download on Pastebin to download the text in the file as a TXT. Then, follow the installation instructions below for your OS.
 
 **Windows Installation Instructions**


### PR DESCRIPTION
As pointed out [here](https://old.reddit.com/r/Roms/comments/117gdup/the_link_is_nonfunctional/), the AES Keys paste has been removed.

This change just points the URL to an archived copy on the Wayback Machine instead.