### PR TITLE
Update sony.md to include decryption instructions for PS3 ISOs

### DIFF
--- a/docs/megathread/misc.md
+++ b/docs/megathread/misc.md
@@ -12,9 +12,9 @@
 | FTP Access | [Details](https://myrient.erista.me/ftp/) |
 | rsync Access | [Details](https://myrient.erista.me/rsync/) |
 
-|**MOBASuite**||
+|**MOBASuite / LoLSuite**||
 | ------ | ------ |
-| mobasuite.com repo | [Link](http://90.230.15.34/) |
+| mobasuite.com/lolsuite.org repo | [Link](http://78.72.143.223/index.php) |
 
 |**Internet Archive**||
 | ------ | ------ |

--- a/docs/megathread/sony.md
+++ b/docs/megathread/sony.md
@@ -180,6 +180,10 @@
 | ------ | ------ |
 | Sony - PlayStation 3 | [Link](https://myrient.erista.me/files/Redump/Sony%20-%20PlayStation%203/) |
 
+**Redump PS3 ISO Decryption Instructions**
+
+Redump PS3 ISOs must be decrypted for use with RPCS3, see [this site](https://consolemods.org/wiki/PS3:Decrypting_PS3_ISOs) for decryption methods.
+
 |**Internet Archive (Alvro)**||
 | ------ | ------ |
 | PS3 Games (# - C) | [Link](https://archive.org/download/PS3_ALVRO_PART_1) |


### PR DESCRIPTION
Added a section explaining that Redump PS3 ISOs are encrypted and included a link containing multiple methods to decrypt them.