### PR TITLE
Link to uBlock Origin Lite for Chrome

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ Below are links to download and install it for certain web browsers.
 
 |**Store Name**|**Links**|
 | ------ | ------ |
-| Chrome Web Store | [Link](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm?hl=en) |
+| Chrome Web Store | [Link](https://chrome.google.com/webstore/detail/ublock-origin-lite/ddkjiahejlhfcafbddmgiahcphecmpfh) |
 | Firefox Add-ons | [Link](https://addons.mozilla.org/en-US/android/addon/ublock-origin/) |
 | Opera Add-ons | [Link](https://addons.opera.com/en/extensions/details/ublock/) |
 


### PR DESCRIPTION
Google has recently updated Chrome’s extension platform, requiring all extensions to migrate to Manifest V3. The original uBlock Origin is built on Manifest V2 and has been disabled in recent Chrome updates.

uBlock Origin Lite is the officially recommended replacement by the original developer. Updating the link ensures that users are directed to the current, actively supported version of the extension that is compatible with the latest Chrome platform requirements.